### PR TITLE
deps: use `mutliformats/rust-multiaddr`@13a1e9e

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1309,7 +1309,7 @@ dependencies = [
  "env_logger 0.10.0",
  "futures",
  "libp2p",
- "multiaddr 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "multiaddr 0.17.1",
 ]
 
 [[package]]
@@ -1491,7 +1491,7 @@ dependencies = [
  "env_logger 0.10.0",
  "futures",
  "libp2p",
- "multiaddr 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "multiaddr 0.17.1",
 ]
 
 [[package]]
@@ -2122,7 +2122,7 @@ dependencies = [
  "env_logger 0.10.0",
  "futures",
  "libp2p",
- "multiaddr 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "multiaddr 0.17.1",
 ]
 
 [[package]]
@@ -2262,7 +2262,7 @@ dependencies = [
  "libp2p-webrtc",
  "libp2p-websocket",
  "libp2p-yamux",
- "multiaddr 0.17.1 (git+https://github.com/p-shahi/rust-multiaddr.git?branch=support-webrtc-protocol-code)",
+ "multiaddr 0.18.0",
  "pin-project",
  "tokio",
 ]
@@ -2331,8 +2331,8 @@ dependencies = [
  "libp2p-mplex",
  "libp2p-noise",
  "log",
- "multiaddr 0.17.1 (git+https://github.com/p-shahi/rust-multiaddr.git?branch=support-webrtc-protocol-code)",
- "multihash",
+ "multiaddr 0.18.0",
+ "multihash 0.17.0",
  "multistream-select",
  "once_cell",
  "parking_lot 0.12.1",
@@ -2504,8 +2504,8 @@ dependencies = [
  "ed25519-dalek",
  "libsecp256k1",
  "log",
- "multiaddr 0.17.1 (git+https://github.com/p-shahi/rust-multiaddr.git?branch=support-webrtc-protocol-code)",
- "multihash",
+ "multiaddr 0.18.0",
+ "multihash 0.17.0",
  "p256 0.12.0",
  "quick-protobuf",
  "quickcheck-ext",
@@ -2981,7 +2981,7 @@ dependencies = [
  "libp2p-ping",
  "libp2p-swarm",
  "log",
- "multihash",
+ "multihash 0.17.0",
  "quick-protobuf",
  "quick-protobuf-codec",
  "quickcheck",
@@ -3239,7 +3239,7 @@ dependencies = [
  "data-encoding",
  "log",
  "multibase",
- "multihash",
+ "multihash 0.17.0",
  "percent-encoding",
  "serde",
  "static_assertions",
@@ -3249,15 +3249,14 @@ dependencies = [
 
 [[package]]
 name = "multiaddr"
-version = "0.17.1"
-source = "git+https://github.com/p-shahi/rust-multiaddr.git?branch=support-webrtc-protocol-code#1bbec9da745e5330a10779253d3c51fefd8dd091"
+version = "0.18.0"
+source = "git+https://github.com/multiformats/rust-multiaddr.git?rev=13a1e9e7da1e26a3aecdec695dc8e5cb0994d4b9#13a1e9e7da1e26a3aecdec695dc8e5cb0994d4b9"
 dependencies = [
  "arrayref",
  "byteorder",
  "data-encoding",
- "log",
  "multibase",
- "multihash",
+ "multihash 0.18.1",
  "percent-encoding",
  "serde",
  "static_assertions",
@@ -3289,6 +3288,17 @@ dependencies = [
  "rand 0.8.5",
  "serde",
  "serde-big-array",
+ "unsigned-varint",
+]
+
+[[package]]
+name = "multihash"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfd8a792c1694c6da4f68db0a9d707c72bd260994da179e6030a5dcee00bb815"
+dependencies = [
+ "core2",
+ "multihash-derive",
  "unsigned-varint",
 ]
 
@@ -3685,7 +3695,7 @@ dependencies = [
  "async-trait",
  "futures",
  "libp2p",
- "multiaddr 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "multiaddr 0.17.1",
 ]
 
 [[package]]

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -18,7 +18,7 @@ futures-timer = "3"
 instant = "0.1.11"
 libp2p-identity = { version = "0.1", path = "../identity", features = ["peerid", "ed25519"] }
 log = "0.4"
-multiaddr = { git = "https://github.com/p-shahi/rust-multiaddr.git", branch = "support-webrtc-protocol-code" }
+multiaddr = { git = "https://github.com/multiformats/rust-multiaddr.git", rev = "13a1e9e7da1e26a3aecdec695dc8e5cb0994d4b9", version = "0.18.0" }
 multihash = { version = "0.17.0", default-features = false, features = ["std"] }
 multistream-select = { version = "0.12.1", path = "../misc/multistream-select" }
 once_cell = "1.17.1"

--- a/identity/Cargo.toml
+++ b/identity/Cargo.toml
@@ -17,7 +17,7 @@ bs58 = { version = "0.4.0", optional = true }
 ed25519-dalek = { version = "1.0.1", optional = true }
 libsecp256k1 = { version = "0.7.0", optional = true }
 log = "0.4"
-multiaddr = { git = "https://github.com/p-shahi/rust-multiaddr.git", branch = "support-webrtc-protocol-code", optional = true }
+multiaddr = { git = "https://github.com/multiformats/rust-multiaddr.git", optional = true, rev = "13a1e9e7da1e26a3aecdec695dc8e5cb0994d4b9", version = "0.18.0" }
 multihash = { version = "0.17.0", default-features = false, features = ["std"], optional = true }
 p256 = { version = "0.12", default-features = false, features = ["ecdsa", "std"], optional = true }
 quick-protobuf = { version = "0.8.1", optional = true }

--- a/libp2p/Cargo.toml
+++ b/libp2p/Cargo.toml
@@ -117,7 +117,7 @@ libp2p-request-response = { version = "0.24.0", path = "../protocols/request-res
 libp2p-swarm = { version = "0.42.0", path = "../swarm" }
 libp2p-wasm-ext = { version = "0.39.0", path = "../transports/wasm-ext", optional = true }
 libp2p-yamux = { version = "0.43.0", path = "../muxers/yamux", optional = true }
-multiaddr = { git = "https://github.com/p-shahi/rust-multiaddr.git", branch = "support-webrtc-protocol-code" }
+multiaddr = { git = "https://github.com/multiformats/rust-multiaddr.git", rev = "13a1e9e7da1e26a3aecdec695dc8e5cb0994d4b9", version = "0.18.0" }
 pin-project = "1.0.0"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]


### PR DESCRIPTION
## Description

I've seen that your `rust-libp2p` fork is used by https://github.com/libp2p/universal-connectivity for the multiaddr `/webrtc-direct` interoperability fixes. 
Fortunately, I saw that the latest https://github.com/multiformats/rust-multiaddr/commit/13a1e9e7da1e26a3aecdec695dc8e5cb0994d4b9 commit includes everything you've done in yourr https://github.com/p-shahi/rust-multiaddr/commit/1bbec9da745e5330a10779253d3c51fefd8dd091 fork.
So, what do you think about using the latest commit of the `multiformats/rust-multiaddr`?

## Notes & open questions

I made this PR by running the following commands:
```bash
cd core
cargo add multiaddr --git https://github.com/multiformats/rust-multiaddr.git --rev 13a1e9e7da1e26a3aecdec695dc8e5cb0994d4b9
cd ../identity
cargo add multiaddr --git https://github.com/multiformats/rust-multiaddr.git --rev 13a1e9e7da1e26a3aecdec695dc8e5cb0994d4b9  --optional
cd ../libp2p
cargo add multiaddr --git https://github.com/multiformats/rust-multiaddr.git --rev 13a1e9e7da1e26a3aecdec695dc8e5cb0994d4b9
```
I'm not sure if this is the proper way because this added an unnecessary field (`..., version = "0.18.0" }`) to the `Cargo.toml`, which I don't have any idea where that `0.18.0` came from. If you have any better way, please correct me.

After this PR is merged, the `rust-libp2p` dependency in the https://github.com/libp2p/universal-connectivity should be updated.

## Change checklist

<!-- Please add a Changelog entry in the appropriate crates and bump the crate versions if needed. See <https://github.com/libp2p/rust-libp2p/blob/master/docs/release.md#development-between-releases>-->

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] A changelog entry has been made in the appropriate crates
